### PR TITLE
Build the calendar fields ourselves

### DIFF
--- a/calendar.js
+++ b/calendar.js
@@ -87,7 +87,7 @@ const calendar = (f,cb) => {
 
     if( filter.length === 1 ){
         calendarName = re_array[ 0 ];
-        calendarDesc = `Spelshechema för ${ re_array[ 0 ] }`;
+        calendarDesc = `Spelschema för ${ re_array[ 0 ] }`;
     }
 
     return_object = `${ return_object }X-WR-CALNAME:${ calendarName }${ newline }`;

--- a/calendar.js
+++ b/calendar.js
@@ -50,7 +50,7 @@ const calendar = (f,cb) => {
     const re_array = [];
     const newline = "\r\n";
     let return_object = `BEGIN:VCALENDAR${ newline }PRODID:-//Google Inc//Google Calendar//EN${ newline }VERSION:2.0${ newline }CALSCALE:GREGORIAN${ newline }X-WR-TIMEZONE:Europe/Stockholm${ newline }`;
-    let calendarName = 'SHL Matcher';
+    let calendarName = 'SHL';
     let calendarDesc = 'Spelschema för SHL';
 
     filter.forEach(function(team) {


### PR DESCRIPTION
This PR makes us build the whole calendar ourselves instead of just copying from source.

It changes the name depending on teams, so if only one team is selected it uses that name. 
This closes #8 

The output ics file is valid according to these validators
http://severinghaus.org/projects/icv/
https://icalendar.org/validator.html

Example output
[hockey-mchockeyface.zip](https://github.com/theseal/hockey-mchockeyface/files/670985/hockey-mchockeyface.zip)
