### PR TITLE
Legacy support for SAIK.

### DIFF
--- a/calendar.js
+++ b/calendar.js
@@ -76,7 +76,7 @@ const calendar = (f,cb) => {
             re_array.push("Malmö Redhawks");
         } else if ( team === "RBK" ) {
             re_array.push("Rögle BK");
-        } else if ( team === "SKE" ) {
+        } else if ( team === "SKE"  || team === "SAIK") {
             re_array.push("Skellefteå AIK");
         } else if ( team === "VLH" ) {
             re_array.push("Växjö Lakers");


### PR DESCRIPTION
Since we changed the short name to the offical SHL short name users that
had configured their client for SAIK will have an empty calendar. Better
add legacy support for SAIK.