### PR TITLE
1.0.0

### DIFF
--- a/calendar.js
+++ b/calendar.js
@@ -159,7 +159,17 @@ const get_shl_games = () => {
 
             shl_games = [];
             component.getAllSubcomponents( 'vevent' ).forEach( ( vevent ) => {
-                const [ home, away ] = vevent.getFirstPropertyValue( 'summary' ).split( ' - ' );
+                let summary = vevent.getFirstPropertyValue( 'summary' );
+
+                // Check if the summary contains a number
+                // Probably means it's a score
+                if ( /\d/.test( summary ) ) {
+                    let matches = summary.match( /(.+?)\d/ );
+
+                    summary = matches[ 1 ].trim();
+                }
+
+                const [ home, away ] = summary.split( ' - ' );
                 const eventData = vevent.toJSON();
                 const event = new ICAL.Component( 'vevent' );
                 event.addPropertyWithValue( 'dtstamp', ICAL.Time.now() );
@@ -169,6 +179,8 @@ const get_shl_games = () => {
                         event.addPropertyWithValue( 'dtstart', property.getFirstValue() );
                     } else if ( property.name === 'dtend' ) {
                         event.addPropertyWithValue( 'dtend', property.getFirstValue() );
+                    } else if ( property.name === 'summary' ) {
+                        event.addPropertyWithValue( 'summary', `${ home } - ${ away }` );
                     } else {
                         event.addProperty( property );
                     }

--- a/calendar.js
+++ b/calendar.js
@@ -1,292 +1,263 @@
-const http = require('http');
-
-const fs = require('fs');
-const util = require('util');
-const readline = require('readline');
-const stream = require('stream');
-
+const ICAL = require( 'ical.js' );
 const request = require("request");
 const cheerio = require("cheerio");
-const cheerioTableparser = require('cheerio-tableparser');
 const moment = require('moment-timezone');
 
 const shl_url = "http://www.shl.se/calendar/66/show/shl.ics";
-const ha_url = "http://www.hockeyallsvenskan.se/matcher/spelschema";
-const ha_table = ".esGameSchedule";
-const newline = "\r\n";
+const ha_url = "http://www.hockeyallsvenskan.se/spelschema/HA_2017_regular";
+const momentFormat = 'YYYY-MM-DDTHH:mm:ss';
 
-let icalData = false;
+let ha_games = [];
+let shl_games = [];
+
 let lastFetch = false;
 
-const ha_download = function( cb ) {
-    let return_object;
-    request(ha_url, function(error, response, body) {
-        var data = [];
-        $ = cheerio.load(body,{ decodeEntities: false });
-        cheerioTableparser($);
-        var array = $(ha_table).parsetable(false, false, false);
-        const re = new RegExp("^( |Datum)$");
+const normaliseName = function normaliseName( name ) {
+    switch ( name ) {
+        case 'AIK':
+            return 'AIK';
+        case 'AIS':
+        case 'Almtuna':
+            return 'Almtuna IS';
+        case 'IFB':
+            return 'Björklöven';
+        case 'BIK':
+        case 'Karlskoga':
+            return 'BIK Karlskoga';
+        case 'BIF':
+            return 'Byrnäs IF';
+        case 'DIF':
+            return 'Djurgården';
+        case 'FHC':
+            return 'Frölunda HC';
+        case 'FBK':
+            return 'Färjestad BK';
+        case 'VIT':
+        case 'Vita Hästen':
+            return 'HC Vita Hästen';
+        case 'HV71':
+            return 'HV71';
+        case 'TRO':
+        case 'Troja/Ljungby':
+            return 'IF Troja-Ljungby';
+        case 'IKO':
+        case 'Oskarshamn':
+            return 'IK Oskarshamn';
+        case 'PAN':
+        case 'Pantern':
+            return 'IK Pantern';
+        case 'KHK':
+            return 'Karlskrona HK';
+        case 'LHC':
+            return 'Linköping HC';
+        case 'LHF':
+            return 'Luleå Hockey';
+        case 'MIF':
+            return 'Malmö Redhawks';
+        case 'MODO':
+            return 'MODO Hockey';
+        case 'MIK':
+            return 'Mora IK';
+        case 'LIF':
+        case 'Leksand':
+            return 'Leksands IF';
+        case 'RBK':
+            return 'Rögle BK';
+        case 'SKE':
+        case 'SAIK':
+            return 'Skellefteå AIK';
+        case 'SSK':
+        case 'Södertälje':
+            return 'Södertjälje SK';
+        case 'TIK':
+        case 'Timrå':
+            return 'Timrå IK';
+        case 'TAIF':
+        case 'Tingsryd':
+            return 'Tingsryds AIF';
+        case 'VVIK':
+        case 'Västervik':
+            return 'Västerviks IK';
+        case 'VLH':
+            return 'Växjö Lakers';
+        case 'ÖRE':
+            return 'Örebro Hockey';
+        default:
+            return name;
+    };
+};
 
-        // 20180302T190000Z
-        const momentFormat = 'YYYYMMDDTHHmmss[Z]';
-
-        array[0].forEach(function(d, i) {
-            const game = array[0][i];
-            if (re.test(game)) {
+const get_ha_games = () => {
+    return new Promise( ( resolve, reject ) => {
+        request( ha_url, ( error, response, body ) => {
+            if ( error ) {
+                reject( error );
                 return false;
-            };
-            const date = array[2][i];
-            if (re.test(date)){
-                return false;
-            };
+            }
 
-            const start_date = moment.tz(date, "Europe/Stockholm");
-            const end_date = moment( start_date ).add( 150, 'minutes' );
+            const $ = cheerio.load( body, {
+                decodeEntities: false,
+            } );
+            const gamesHtml = $( '.rmss_c-schedule-game__row-wrapper' );
+            ha_games = [];
 
-            const home = array[4][i];
-            const away = array[6][i];
+            gamesHtml.each( ( index, element ) => {
+                const $element = $( element );
 
-            var row = {
-                "game": game,
-                "start_date": start_date.utc().format( momentFormat ),
-                "end_date": end_date.utc().format( momentFormat ),
-                "home": home,
-                "away": away,
-            };
+                // Skip played games
+                if ( $element.data( 'game-mode' ) === 'played' ) {
+                    return true;
+                }
 
-            data.push(row);
-        })
+                const date = $element.data( 'game-date' );
+                const time = $element.find( '.rmss_c-schedule-game__live-info' ).first().text();
 
-        data.forEach(function(value) {
-            const game = value.game;
-            const start_date = value.start_date;
-            const end_date = value.end_date;
-            const home = value.home;
-            const away = value.away;
-            return_object += `BEGIN:VEVENT${newline}UID:${start_date}@${home}${newline}SUMMARY:${home} - ${away}${newline}DESCRIPTION:Omgång ${game}${ newline }DTSTART:${start_date}${newline}DTEND:${end_date}${ newline }END:VEVENT${newline}`;
+                const start_date = moment.tz( `${ date } ${ time }`, "Europe/Stockholm");
+                const end_date = moment( start_date ).add( 150, 'minutes' );
+
+                const game = $element.find( '.rmss_c-schedule-game__info__round-number' ).text().match( /\d+/g )[ 0 ];
+
+                let home = $element.find( '.rmss_c-schedule-game__team.is-home-team .rmss_c-schedule-game__team-name' ).first().text();
+                let away = $element.find( '.rmss_c-schedule-game__team.is-away-team .rmss_c-schedule-game__team-name' ).first().text();
+                home = normaliseName( home );
+                away = normaliseName( away );
+
+                const event = new ICAL.Component( 'vevent' );
+                event.addPropertyWithValue( 'uid', `${ game }-${ home }-${ away }` );
+                event.addPropertyWithValue( 'summary', `${ home } - ${ away }` );
+                event.addPropertyWithValue( 'description', `Omgång ${ game }` );
+                event.addPropertyWithValue( 'dtstart', ICAL.Time.fromString( start_date.utc().format( momentFormat ) ) );
+                event.addPropertyWithValue( 'dtend', ICAL.Time.fromString( end_date.utc().format( momentFormat ) ) );
+                event.addPropertyWithValue( 'dtstamp', ICAL.Time.now() );
+
+                ha_games.push( {
+                    event: event,
+                    home: home,
+                    away: away,
+                } );
+            } );
+
+            resolve();
+
+            return true;
         });
 
-        cb( null, return_object );
+        return true;
     });
 };
 
-
-const download = function(shl_url, cb) {
-    let fetch = true;
-
-    if (icalData) {
-        const now = new Date().getTime() / 1000;
-        const diff = now - 3600;
-
-        if (diff < lastFetch ) {
-            fetch = false;
-        };
-    };
-
-    if (!fetch) {
-        cb(null);
-    } else {
-        const request = http.get(shl_url, function(response) {
-            let bufferData = [];
-
-            response.on( 'data', ( chunk ) => {
-                bufferData.push( chunk );
-            });
-
-            response.on('end', function() {
-                ha_download( function(error, data) {
-                    icalData = `${Buffer.concat( bufferData )}${data}`;
-                    lastFetch = new Date().getTime() / 1000;
-                    cb(null);
-                });
-            });
-        }).on('error', function(err) {
-            if (cb) {
-                cb(err);
+const get_shl_games = () => {
+    return new Promise( ( resolve, reject ) => {
+        request( shl_url, ( error, response, body ) => {
+            if ( error ) {
+                reject( error );
 
                 return false;
             }
+            const shl_data = ICAL.parse( body );
+            const component = new ICAL.Component( shl_data );
+
+            shl_games = [];
+            component.getAllSubcomponents( 'vevent' ).forEach( ( vevent ) => {
+                const [ home, away ] = vevent.getFirstPropertyValue( 'summary' ).split( ' - ' );
+                const eventData = vevent.toJSON();
+                const event = new ICAL.Component( 'vevent' );
+                event.addPropertyWithValue( 'dtstamp', ICAL.Time.now() );
+
+                vevent.getAllProperties().map( ( property ) => {
+                    if ( property.name === 'dtstart' ) {
+                        event.addPropertyWithValue( 'dtstart', property.getFirstValue() );
+                    } else if ( property.name === 'dtend' ) {
+                        event.addPropertyWithValue( 'dtend', property.getFirstValue() );
+                    } else {
+                        event.addProperty( property );
+                    }
+                } );
+
+                shl_games.push( {
+                    event: event,
+                    home: normaliseName( home ),
+                    away: normaliseName( away ),
+                } );
+            } );
+
+            resolve();
+
+            return true;
         });
-    };
+
+        return true;
+    } );
+};
+
+
+const update_games = function() {
+    return new Promise (( resolve, reject ) => {
+        let fetch = true;
+
+        const now = new Date().getTime() / 1000;
+        const diff = now - 3600;
+
+        if ( diff < lastFetch ) {
+            resolve();
+
+            return true;
+        };
+
+        const updates = [];
+        updates.push( get_shl_games() );
+        updates.push( get_ha_games() );
+
+        Promise.all( updates )
+            .then( () => {
+                resolve();
+            })
+            .catch( ( someError ) => {
+                reject( someError );
+            });
+    });
 };
 
 const calendar = (f,cb) => {
     const filter = [].concat(f);
-    const re_array = [];
-    let return_object = `BEGIN:VCALENDAR${ newline }PRODID:-//Hockey McHF//Hockey McHockeyFace//EN${ newline }VERSION:2.0${ newline }CALSCALE:GREGORIAN${ newline }X-WR-TIMEZONE:Europe/Stockholm${ newline }`;
-    let shl = false;
-    let ha = false;
+    const include_teams = [];
+    const calendar = new ICAL.Component( 'vcalendar' );
+    calendar.addPropertyWithValue( 'prodid', '-//Hockey McHF//Hockey McHockeyFace//EN' );
+    calendar.addPropertyWithValue( 'version', '2.0' );
+    calendar.addPropertyWithValue( 'calscale', 'GREGORIAN' );
+    calendar.addPropertyWithValue( 'x-wr-timezone', 'Europe/Stockholm' );
 
     filter.forEach(function(team) {
-        // SHL
-        if (team === "BIF") {
-            re_array.push("Brynäs IF");
-            shl = true;
-        } else if ( team === "DIF" ) {
-            re_array.push("Djurgården");
-            shl = true;
-        } else if ( team === "FHC" ) {
-            re_array.push("Frölunda HC");
-            shl = true;
-        } else if ( team === "FBK" ) {
-            re_array.push("Färjestad BK");
-            shl = true;
-        } else if ( team === "HV71" ) {
-            re_array.push("HV71");
-            shl = true;
-        } else if ( team === "KHK" ) {
-            re_array.push("Karlskrona HK");
-            shl = true;
-        } else if ( team === "LHC" ) {
-            re_array.push("Linköping HC");
-            shl = true;
-        } else if ( team === "LHF" ) {
-            re_array.push("Luleå Hockey");
-            shl = true;
-        } else if ( team === "MIF" ) {
-            re_array.push("Malmö Redhawks");
-            shl = true;
-        } else if ( team === "MIK" ) {
-            re_array.push("Mora IK");
-            shl = true;
-        } else if ( team === "RBK" ) {
-            re_array.push("Rögle BK");
-            shl = true;
-        } else if ( team === "SKE"  || team === "SAIK") {
-            re_array.push("Skellefteå AIK");
-            shl = true;
-        } else if ( team === "VLH" ) {
-            re_array.push("Växjö Lakers");
-            shl = true;
-        } else if ( team === "ÖRE" ) {
-            re_array.push("Örebro Hockey");
-            shl = true;
-        // HA
-        } else if ( team === "AIK" ) {
-            re_array.push("AIK");
-            ha = true;
-        } else if ( team === "AIS" ) {
-            re_array.push("Almtuna IS");
-            ha = true;
-        } else if ( team === "IFB" ) {
-            re_array.push("Björklöven");
-            ha = true;
-        } else if ( team === "BIK" ) {
-            re_array.push("BIK Karlskoga");
-            ha = true;
-        } else if ( team === "VIT" ) {
-            re_array.push("HC Vita Hästen");
-            ha = true;
-        } else if ( team === "TRO" ) {
-            re_array.push("IF Troja-Ljungby");
-            ha = true;
-        } else if ( team === "IKO" ) {
-            re_array.push("IK Oskarshamn");
-            ha = true;
-        } else if ( team === "PAN" ) {
-            re_array.push("IK Pantern");
-            ha = true;
-        } else if ( team === "MODO" ) {
-            re_array.push("MODO Hockey");
-            ha = true;
-        } else if ( team === "LIF" ) {
-            re_array.push("Leksands IF");
-            ha = true;
-        } else if ( team === "SSK" ) {
-            re_array.push("Södertjälje SK");
-            ha = true;
-        } else if ( team === "TIK" ) {
-            re_array.push("Timrå IK");
-            ha = true;
-        } else if ( team === "TAIF" ) {
-            re_array.push("Tingsryds AIF");
-            ha = true;
-        } else if ( team === "VVIK" ) {
-            re_array.push("Västerviks IK");
-            ha = true;
-        };
+        include_teams.push( normaliseName( team ) );
     });
 
-    let calendarName;
-    let calendarDesc;
-
-    if (shl && ! ha) {
-        calendarName = 'SHL';
-        calendarDesc = 'Spelschema för SHL';
-    } else if (ha && ! shl) {
-        calendarName = 'HA';
-        calendarDesc = 'Spelschema för HA';
-    } else {
-        calendarName = 'Svensk hockey';
-        calendarDesc = 'Spelschema för svensk hockey';
-    };
+    calendar.addPropertyWithValue( 'x-wr-calname', 'Svensk hockey' );
+    calendar.addPropertyWithValue( 'x-wr-caldesc', 'Spelschema för svensk hockey' );
 
     if( filter.length === 1 && filter[0]){
-        calendarName = re_array[ 0 ];
-        calendarDesc = `Spelschema för ${ re_array[ 0 ] }`;
+        calendar.updatePropertyWithValue( 'x-wr-calname', include_teams[ 0 ] );
+        calendar.updatePropertyWithValue( 'x-wr-caldesc', `Spelschema för ${ include_teams[ 0 ] }` );
     }
 
-    return_object = `${ return_object }X-WR-CALNAME:${ calendarName }${ newline }`;
-    return_object = `${ return_object }X-WR-CALDESC:${ calendarDesc }${ newline }`;
-
-    const global_re = re_array.join("|");
-
-    download(shl_url, (err) => {
-        if (err) {
-            cb(err);
-
-            return false;
-        }
-
-        let readStream = new stream.PassThrough();
-        readStream.end( icalData );
-
-        const lineReader = readline.createInterface({
-            input: readStream
-        });
-
-        let in_event = false;
-        let event_data = [];
-        let print_event = false;
-
-        lineReader.on('line', (line) => {
-            if (line.match("^BEGIN:VEVENT")) {
-                in_event = true;
-                event_data = [];
+    update_games()
+        .then( () => {
+            for ( let i = 0; i < shl_games.length; i = i + 1 ) {
+                if ( include_teams.includes( shl_games[ i ].home ) || include_teams.includes( shl_games[ i.away ] ) ) {
+                    calendar.addSubcomponent( shl_games[ i ].event );
+                }
             }
 
-            if (in_event) {
-                event_data.push(line);
+            for ( let i = 0; i < ha_games.length; i = i + 1 ) {
+                if ( include_teams.includes( ha_games[ i ].home ) || include_teams.includes( ha_games[ i.away ] ) ) {
+                    calendar.addSubcomponent( ha_games[ i ].event );
+                }
             }
 
-            if (line.match("^END:VEVENT")) {
-                print_event = false;
-                in_event = false;
-
-                event_data.forEach(function(entry) {
-                    re = /^SUMMARY/;
-                    if (entry.match(re) && entry.match(global_re)) {
-                        print_event = true;
-                    };
-                });
-
-                if (print_event) {
-                    event_data.forEach(function(entry) {
-                        return_object += entry + newline;
-                    });
-                };
-            };
-        });
-
-        lineReader.on('close', () => {
-            return_object = `${ return_object }END:VCALENDAR`;
-            cb(null, return_object);
-        });
-
-        lineReader.on('error', ( error ) => {
-            cb(error);
-        });
-    });
+            cb( null, calendar.toString() );
+        } )
+        .catch( ( someError ) => {
+            console.error( someError );
+        } );
 };
 
 module.exports = calendar;

--- a/package.json
+++ b/package.json
@@ -1,20 +1,19 @@
 {
   "name": "hockey-mchockeyface",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "description": " Useful tools for Svenska Hockeyligan ",
   "engines": {
-    "node": "8.1.4"
+    "node": "8.4.0"
   },
   "main": "app.js",
   "scripts": {
     "start": "node app.js"
   },
   "dependencies": {
-    "cheerio": "1.0.0-rc.1",
-    "cheerio-tableparser": "1.0.1",
-    "dateformat": "2.0.0",
+    "cheerio": "^1.0.0-rc.1",
     "express": "4.14.0",
     "follow-redirects": "1.2.1",
+    "ical.js": "^1.2.2",
     "moment-timezone": "^0.5.13",
     "request": "2.81.0",
     "serve-favicon": "2.3.2"


### PR DESCRIPTION
So I started working on #22 and while doing so ended up rewriting the whole thing...

Basically, the flow is now more clear.
It downloads the feeds and keeps an internal index of all the games with proper iCal events.
Then when you request a feed it just looks through those feeds and adds the events that match the teams you want.

Fixes #22, #18, #10 & #3 